### PR TITLE
Wait for future to complete in ScalaTest before and after methods.

### DIFF
--- a/src/test/scala/slick/additions/KeyedTableTests.scala
+++ b/src/test/scala/slick/additions/KeyedTableTests.scala
@@ -66,7 +66,7 @@ class KeyedTableTests extends FunSuite with Matchers with BeforeAndAfter {
     }
   }
 
-  val db = Database.forURL("jdbc:h2:test", driver = "org.h2.Driver")
+  val db = Database.forURL("jdbc:h2:./test", driver = "org.h2.Driver")
 
   val schema = Phones.schema ++ People.schema
 

--- a/src/test/scala/slick/additions/KeyedTableTests.scala
+++ b/src/test/scala/slick/additions/KeyedTableTests.scala
@@ -71,11 +71,11 @@ class KeyedTableTests extends FunSuite with Matchers with BeforeAndAfter {
   val schema = Phones.schema ++ People.schema
 
   before {
-    db run schema.create
+    Await.result(db run schema.create, Duration.Inf)
   }
 
   after {
-    db run schema.drop
+    Await.result(db run schema.drop, Duration.Inf)
   }
 
   test("OneToMany") {


### PR DESCRIPTION
Should wait for Slick future to complete when creating and dropping schemas in ScalaTest before and after methods.