### PR TITLE
build.sbt: Re-enable aggregating

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val slickVersion = "3.5.0-M5"
 lazy val `slick-additions` =
   (project in file("."))
     .dependsOn(`slick-additions-entity`.jvm)
-//    .aggregate(`slick-additions-entity`.jvm, `slick-additions-entity`.js, `slick-additions-codegen`)
+    .aggregate(`slick-additions-entity`.jvm, `slick-additions-entity`.js, `slick-additions-codegen`)
     .settings(
       libraryDependencies ++= Seq(
         "com.typesafe.slick" %% "slick"           % slickVersion,


### PR DESCRIPTION
Was disabled temporarily while working on Scala 3 support.

It's necessary to specify it explicitly when the project
in the base directory is a custom project, apparently.
