### PR TITLE
Alias Lookup#sameKey as =#=

### DIFF
--- a/slick-additions-entity/src/main/scala/slick/additions/entity/Entity.scala
+++ b/slick-additions-entity/src/main/scala/slick/additions/entity/Entity.scala
@@ -20,6 +20,7 @@ sealed trait Lookup[K, +A] extends EntityRef[K, A] {
   def valueOption: Option[A] = foldLookup(_ => None, ke => Some(ke.value))
 
   def sameKey[B](that: Lookup[K, B])(implicit ev: A <:< B) = this.key == that.key
+  def =#=[B](that: Lookup[K, B])(implicit ev: A <:< B)     = sameKey(that)
 
   def toEntityKey: EntityKey[K, A]
 }


### PR DESCRIPTION
This makes it easier to change the order of operands, which may be necessary for it to typecheck in some cases.

For instance, given the following code:

xs.exists(_.lookup.sameKey(myLookup))

If x.lookup is a Lookup[Int, A] and myLookup is a Lookup[Int, B], then if A <: B this will compile.

But if B <: A it will need to be changed to one of the following

xs.exists(x => myLookup.sameKey(x.entity))  // can't use _ shorthand
xs.exists(myLookup sameKey _.entity)        // Scala 3 doesn't like infix alphabetic methods, unidiomatic
xs.exists(myLookup =#= _.entity)            // now possible

Additionally, editors (such as IntelliJ) may have a hotkey to change the order of operands, which may not work for
alphabetic methods, even in infix position.
