### PR TITLE
Fix a crash (old slick bug)

### DIFF
--- a/src/main/scala/slick/additions/AdditionsProfile.scala
+++ b/src/main/scala/slick/additions/AdditionsProfile.scala
@@ -50,7 +50,7 @@ trait AdditionsProfile { this: JdbcProfile =>
 
       def * = all
 
-      def lookup = column[Lookup[K, V]](keyColumnName, keyColumnOptions: _*)
+      def lookup: MappedProjection[Lookup[K, V]] = key.<>(EntityKey.apply[K, V], lookup => Some(lookup.key))
     }
 
     class KeyedTableQueryBase[K: BaseColumnType, A, T <: KeyedTable[K, A]](cons: Tag => T with KeyedTable[K, A])


### PR DESCRIPTION
Bring back part of the LookupRep workaround
(removed in e3949932ea079e93dba55cdec242a3c7ff029f7a)
