### PR TITLE
EntityTable: defining key as a cast makes it somewhat usable

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java system

--- a/src/main/scala/slick/additions/AdditionsProfile.scala
+++ b/src/main/scala/slick/additions/AdditionsProfile.scala
@@ -42,7 +42,7 @@ trait AdditionsProfile { this: JdbcProfile =>
       def Ent(v: Value) = new KeylessEntity[Key, Value](v)
 
       @deprecated("Using key in an EntityTable is unsupported and may lead to crashes", "0.13.0")
-      override def key = super.key
+      override def key = lookup.asColumnOf[Key]
 
       def tableQuery: Query[EntityTable[K, V], this.KEnt, Seq]
 


### PR DESCRIPTION
This way using it won't pollute slick's internal model. OTOH it can no longer be used for inserts.
