### PR TITLE
Upgrade Slick version to 3.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val `slick-additions-entity` =
   crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure)
     .settings()
 
-val slickVersion = "3.5.2"
+val slickVersion = "3.6.0"
 
 lazy val `slick-additions` =
   (project in file("."))


### PR DESCRIPTION
Updated the Slick dependency from version 3.5.2 to 3.6.0 in build.sbt. This ensures compatibility with the latest features and bug fixes in Slick. No other changes were made.
