### PR TITLE
Add logging when column type is not matched

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
@@ -11,6 +11,7 @@ import slick.dbio.DBIO
 import slick.jdbc.JdbcProfile
 import slick.jdbc.meta._
 
+import org.slf4j.LoggerFactory
 
 /** Information about a table obtained from the Slick JDBC metadata APIs
   */
@@ -64,6 +65,8 @@ case class TableConfig(
   * snake_case names in the database, and names model classes by appending `Row` to the camel-cased table name.
   */
 trait GenerationRules {
+  private val logger = LoggerFactory.getLogger(getClass)
+
   def packageName: String
   def container: String
   def extraImports                         = List.empty[String]
@@ -130,7 +133,10 @@ trait GenerationRules {
 
   def columnConfig(column: MColumn, currentTableMetadata: TableMetadata, all: Seq[TableMetadata]): ColumnConfig = {
     val ident    = Term.Name(snakeToCamel(column.name))
-    val typ0     = baseColumnType(currentTableMetadata, all).applyOrElse(column, (_: MColumn) => typ"Nothing")
+    val typ0     = baseColumnType(currentTableMetadata, all).applyOrElse(column, (_: MColumn) => {
+      logger.warn(s"Column type not matched for column: ${currentTableMetadata.table.name} ${column.name}")
+      typ"Nothing"
+    })
     val default0 = baseColumnDefault(currentTableMetadata, all).lift(column)
 
     val (typ, default) =


### PR DESCRIPTION
Fixes #360

Add logging for unmatched column types in `columnConfig` method.

* Import `org.slf4j.LoggerFactory`.
* Add a private logger field using `LoggerFactory.getLogger`.
* Log a warning when a column type is not matched in `columnConfig` method.
* Enhance error handling in `columnConfig` method to provide more informative error messages for unmatched column types.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nafg/slick-additions/pull/465?shareId=281fdbc0-8152-4216-85de-c058dcc47eeb).