### PR TITLE
feat(codegen)!: unify and clarify table class naming in GenerationRules and NamingRules

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
@@ -77,9 +77,8 @@ class GenerationRules {
 
   // noinspection ScalaWeakerAccess
   final protected def columnNameToIdentifier(name: String)      = namingRules.columnNameToIdentifier(name)
-  // noinspection ScalaWeakerAccess
-  final protected def tableNameToIdentifier(name: MQName)       = namingRules.tableNameToIdentifier(name)
   final protected def modelClassName(tableName: MQName): String = namingRules.modelClassName(tableName)
+  final protected def tableClassName(tableName: MQName): String = namingRules.tableClassName(tableName)
 
   /** Determine the base Scala type for a column. If the column is nullable, the type returned from this method will be
     * wrapped in `Option[...]`.
@@ -174,7 +173,7 @@ class GenerationRules {
   def tableConfig(currentTableMetadata: TableMetadata, all: Seq[TableMetadata]) =
     TableConfig(
       tableMetadata = currentTableMetadata,
-      tableClassName = tableNameToIdentifier(currentTableMetadata.table.name),
+      tableClassName = tableClassName(currentTableMetadata.table.name),
       modelClassName = modelClassName(currentTableMetadata.table.name),
       columns = columnConfigs(currentTableMetadata, all)
     )

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/NamingRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/NamingRules.scala
@@ -6,7 +6,8 @@ import slick.jdbc.meta.MQName
 trait NamingRules {
   def columnNameToIdentifier(name: String): String = snakeToCamel(name)
   def tableNameToIdentifier(name: MQName): String  = snakeToCamel(name.name).capitalize
-  def modelClassName(tableName: MQName): String
+  def modelClassName(tableName: MQName): String    = tableNameToIdentifier(tableName)
+  def tableClassName(tableName: MQName): String    = tableNameToIdentifier(tableName)
 }
 
 object NamingRules {
@@ -46,8 +47,8 @@ object NamingRules {
     */
   // noinspection ScalaUnusedSymbol
   trait TablePluralModelSingular extends NamingRules {
-    override def tableNameToIdentifier(name: MQName) = {
-      val base = super.tableNameToIdentifier(name)
+    override def tableClassName(name: MQName) = {
+      val base = tableNameToIdentifier(name)
       if (base.endsWith("s"))
         base
       else if (base.endsWith("x"))
@@ -57,8 +58,6 @@ object NamingRules {
       else
         base + "s"
     }
-
-    override def modelClassName(tableName: MQName) = s"${snakeToCamel(tableName.name).capitalize}"
   }
 
   /** $TablePluralModelSingular */


### PR DESCRIPTION
Introduced a dedicated tableClassName method in NamingRules to distinctly handle table class
naming separate from model class naming. Updated GenerationRules to use this new method
instead of the previously used tableNameToIdentifier for tableClassName. This change improves
clarity and flexibility in naming conventions, especially for pluralization rules applied in
TablePluralModelSingular, ensuring consistent and explicit naming behavior for generated code.
