### PR TITLE
refactor(codegen): Make EntityGenerationRules output `Lookup` fully qualified

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/EntityGenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/EntityGenerationRules.scala
@@ -1,6 +1,6 @@
 package slick.additions.codegen
 
-import slick.additions.codegen.ScalaMetaDsl._
+import slick.additions.codegen.ScalaMetaDsl.*
 
 
 /** Uses `slick-additions-entity` `Lookup` for foreign key fields.
@@ -8,14 +8,15 @@ import slick.additions.codegen.ScalaMetaDsl._
   * Generated code requires `slick-additions-entity`.
   */
 trait EntityGenerationRules extends GenerationRules {
-  override def extraImports = "slick.additions.entity.Lookup" :: super.extraImports
-
   override def baseColumnType(currentTableMetadata: TableMetadata, all: Seq[TableMetadata]) =
     Function.unlift { column =>
       super.baseColumnType(currentTableMetadata, all).lift(column).map { keyType =>
         currentTableMetadata.foreignKeys.find(_.fkColumn == column.name) match {
           case None     => keyType
-          case Some(fk) => typ"Lookup".typeApply(keyType, typ"${modelClassName(fk.pkTable)}")
+          case Some(fk) =>
+            term"slick".termSelect("additions").termSelect("entity")
+              .typeSelect(typ"Lookup")
+              .typeApply(keyType, typ"${modelClassName(fk.pkTable)}")
         }
       }
     }

--- a/slick-additions-codegen/src/test/resources/entity/Models.scala
+++ b/slick-additions-codegen/src/test/resources/entity/Models.scala
@@ -1,5 +1,4 @@
 package entity
-import slick.additions.entity.Lookup
 case class ColorsRow(name: String)
 case class PeopleRow(
     first: String,
@@ -7,7 +6,7 @@ case class PeopleRow(
     city: String = "New York",
     dateJoined: java.time.LocalDate = java.time.LocalDate.now(),
     balance: BigDecimal = BigDecimal("0.0"),
-    bestFriend: Option[Lookup[Long, PeopleRow]] = None,
+    bestFriend: Option[slick.additions.entity.Lookup[Long, PeopleRow]] = None,
     col8: Option[Double] = None,
     col9: Option[Boolean] = None,
     col10: Option[Int] = None,

--- a/slick-additions-codegen/src/test/resources/entity/TableModules.scala
+++ b/slick-additions-codegen/src/test/resources/entity/TableModules.scala
@@ -6,7 +6,7 @@ trait SlickProfile extends slick.jdbc.H2Profile with AdditionsProfile {
 }
 object SlickProfile extends SlickProfile
 import SlickProfile.api._
-import slick.lifted.MappedProjection, slick.additions.entity.Lookup
+import slick.lifted.MappedProjection
 object TableModules {
   object Colors extends EntityTableModule[Long, ColorsRow]("colors") {
     class Row(tag: Tag) extends BaseEntRow(tag) {
@@ -21,24 +21,27 @@ object TableModules {
       val city       = column[String]("city")
       val dateJoined = column[java.time.LocalDate]("date_joined")
       val balance    = column[BigDecimal]("balance")
-      val bestFriend = column[Option[Lookup[Long, PeopleRow]]]("best_friend")
-      val col8       = column[Option[Double]]("col8")
-      val col9       = column[Option[Boolean]]("col9")
-      val col10      = column[Option[Int]]("col10")
-      val col11      = column[Option[Int]]("col11")
-      val col12      = column[Option[Int]]("col12")
-      val col13      = column[Option[Int]]("col13")
-      val col14      = column[Option[Int]]("col14")
-      val col15      = column[Option[Int]]("col15")
-      val col16      = column[Option[Int]]("col16")
-      val col17      = column[Option[Int]]("col17")
-      val col18      = column[Option[Int]]("col18")
-      val col19      = column[Option[Int]]("col19")
-      val col20      = column[Option[Int]]("col20")
-      val col21      = column[Option[Int]]("col21")
-      val col22      = column[Option[Int]]("col22")
-      val col23      = column[Option[Int]]("col23")
-      val col24      = column[Option[Int]]("col24")
+      val bestFriend =
+        column[Option[slick.additions.entity.Lookup[Long, PeopleRow]]](
+          "best_friend"
+        )
+      val col8                                 = column[Option[Double]]("col8")
+      val col9                                 = column[Option[Boolean]]("col9")
+      val col10                                = column[Option[Int]]("col10")
+      val col11                                = column[Option[Int]]("col11")
+      val col12                                = column[Option[Int]]("col12")
+      val col13                                = column[Option[Int]]("col13")
+      val col14                                = column[Option[Int]]("col14")
+      val col15                                = column[Option[Int]]("col15")
+      val col16                                = column[Option[Int]]("col16")
+      val col17                                = column[Option[Int]]("col17")
+      val col18                                = column[Option[Int]]("col18")
+      val col19                                = column[Option[Int]]("col19")
+      val col20                                = column[Option[Int]]("col20")
+      val col21                                = column[Option[Int]]("col21")
+      val col22                                = column[Option[Int]]("col22")
+      val col23                                = column[Option[Int]]("col23")
+      val col24                                = column[Option[Int]]("col24")
       def mapping: MappedProjection[PeopleRow] = (
         (
           first,


### PR DESCRIPTION
This way it is resilient to shadowing.

The import is no longer needed.
