### PR TITLE
feat(codegen): add ColName extractor for table and column name matching

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/package.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/package.scala
@@ -27,4 +27,16 @@ package object codegen {
   object ColType {
     def unapply(col: MColumn) = Some((col.sqlType, col.typeName.toLowerCase, col.columnDef))
   }
+
+  /** Extractor for matching a column by its table name and column name. Useful in `columnTypeOverride` and
+    * `includeColumn` overrides for per-column matching.
+    *
+    * @example
+    *   {{{
+    * case ColName("hotline", "phone_number") => typ"PhoneNumber"
+    *   }}}
+    */
+  object ColName {
+    def unapply(col: MColumn): Some[(String, String)] = Some((col.table.name, col.name))
+  }
 }


### PR DESCRIPTION
Introduced the ColName extractor object to enable pattern matching on columns by their
associated table name and column name. This addition facilitates more precise overrides in
code generation, such as columnTypeOverride and includeColumn, by allowing users to match
specific columns easily. The new extractor improves customization capabilities in the
slick-additions codegen module.
