### PR TITLE
Update dynverGitDescribeOutput to use custom snapshot logic

### DIFF
--- a/ci.sbt
+++ b/ci.sbt
@@ -16,7 +16,14 @@ inThisBuild(List(
   developers                          := List(
     Developer("nafg", "Naftoli Gugenheim", "98384+nafg@users.noreply.github.com", url("https://github.com/nafg"))
   ),
-  dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
+  dynverGitDescribeOutput             :=
+    dynverGitDescribeOutput.value.map { o =>
+      if (o.isSnapshot()) {
+        // Trick to get "-SNAPSHOT" without the other bits
+        o.copy(commitSuffix = sbtdynver.GitCommitSuffix(0, ""), dirtySuffix = sbtdynver.GitDirtySuffix("+"))
+      } else
+        o
+    },
   dynverSonatypeSnapshots             := true,
   githubWorkflowScalaVersions         := githubWorkflowScalaVersions.value.map(_.replaceFirst("\\d+$", "x")),
   githubWorkflowTargetTags ++= Seq("v*"),


### PR DESCRIPTION
Simplifies obtaining "-SNAPSHOT" while customizing commit and dirty suffixes for snapshot builds.
