### PR TITLE
Add Scaladoc for table-specific code generators

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/ModelsFileCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/ModelsFileCodeGenerator.scala
@@ -5,6 +5,11 @@ import scala.meta.*
 import slick.additions.codegen.ScalaMetaDsl.{defClass, termParam}
 
 
+/** Per-table code generator that produces a model case class for one table.
+  *
+  * @see
+  *   [[KeylessModelsObjectCodeGenerator]] which filters out primary key columns
+  */
 class ModelsObjectCodeGenerator(protected val tableConfig: TableConfig) extends ObjectCodeGenerator {
   protected def columnConfigs = tableConfig.columns
 

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/ObjectCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/ObjectCodeGenerator.scala
@@ -3,6 +3,16 @@ package slick.additions.codegen
 import scala.meta.Stat
 
 
+/** Per-table code generator that produces Scalameta statements for one table.
+  *
+  * A [[FileCodeGenerator]] creates one `ObjectCodeGenerator` per table (via `objectCodeGenerator`) and collects all
+  * their statements into a single generated file.
+  *
+  * @see
+  *   [[ModelsObjectCodeGenerator]] for model case class generation
+  * @see
+  *   [[TablesObjectCodeGenerator]] for Slick table definition generation
+  */
 trait ObjectCodeGenerator {
   def statements: List[Stat]
 }

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/TablesFileCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/TablesFileCodeGenerator.scala
@@ -30,6 +30,11 @@ trait TablesFileCodeGenerator extends FileCodeGenerator {
     new TablesObjectCodeGenerator(tableConfig)
 }
 
+/** Per-table code generator that produces a standard Slick table definition (a `Table` subclass and `TableQuery` val).
+  *
+  * @see
+  *   [[EntityTableModulesObjectCodeGenerator]] which extends this to use slick-additions `EntityTableModule`
+  */
 class TablesObjectCodeGenerator(protected val tableConfig: TableConfig) extends ObjectCodeGenerator {
   // noinspection ScalaWeakerAccess
   def isDefaultSchema(schema: String) = schema == "public"


### PR DESCRIPTION
Enhances clarity of `ObjectCodeGenerator`, `TablesObjectCodeGenerator`, and `ModelsObjectCodeGenerator` by adding detailed Scaladoc comments with references to related classes.
