### PR TITLE
Add customization hooks to model and entity table codegen

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/EntityTableModulesCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/EntityTableModulesCodeGenerator.scala
@@ -70,9 +70,12 @@ trait EntityTableModulesObjectCodeGenerator extends TablesObjectCodeGenerator {
   protected def partitionPrimaryKey: (List[ColumnConfig], List[ColumnConfig]) =
     tableConfig.columns.partition(c => tableConfig.tableMetadata.primaryKeys.exists(_.column == c.column.name))
 
-  // noinspection ScalaWeakerAccess
-  protected def tableModuleBase(pk: ColumnConfig) =
+  protected def tableModuleBaseType(pk: ColumnConfig): Type =
     typ"EntityTableModule".typeApply(pk.scalaType, typ"${tableConfig.modelClassName}")
+
+  // noinspection ScalaWeakerAccess
+  protected def tableModuleBases(pk: ColumnConfig) =
+    Seq(init(tableModuleBaseType(pk), Seq(Seq(Lit.String(pk.column.table.name)))))
 
   // noinspection ScalaWeakerAccess
   protected def tableRowBase = typ"BaseEntRow"
@@ -84,10 +87,7 @@ trait EntityTableModulesObjectCodeGenerator extends TablesObjectCodeGenerator {
     partitionPrimaryKey match {
       case (Seq(pk), otherCols) =>
         List(
-          defObject(
-            Term.Name(tableConfig.tableClassName),
-            init(tableModuleBase(pk), Seq(Seq(Lit.String(tableConfig.tableMetadata.table.name.name))))
-          )(
+          defObject(Term.Name(tableConfig.tableClassName), tableModuleBases(pk)*)(
             List(
               defClass(
                 "Row",

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/ModelsFileCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/ModelsFileCodeGenerator.scala
@@ -2,16 +2,26 @@ package slick.additions.codegen
 
 import scala.meta.*
 
-import slick.additions.codegen.ScalaMetaDsl.{defClass, termParam}
+import slick.additions.codegen.ScalaMetaDsl.{defClass, defObject, termParam}
 
 
-/** Per-table code generator that produces a model case class for one table.
+/** Per-table code generator that produces a model case class (and optionally a companion object) for one table.
+  *
+  * Override the hook methods to customize the generated case class and companion:
+  *   - [[modelClassBases]] to add base types to the case class
+  *   - [[modelObjectBases]] to generate a companion object with base types
   *
   * @see
   *   [[KeylessModelsObjectCodeGenerator]] which filters out primary key columns
   */
 class ModelsObjectCodeGenerator(protected val tableConfig: TableConfig) extends ObjectCodeGenerator {
   protected def columnConfigs = tableConfig.columns
+
+  /** Base types for the model case class (the `extends` clause).
+    *
+    * For example, returning `List(init(typ"MyOps"))` generates `case class MyModel(...) extends MyOps`.
+    */
+  protected def modelClassBases: List[Init] = Nil
 
   protected def modelClass =
     defClass(
@@ -20,10 +30,28 @@ class ModelsObjectCodeGenerator(protected val tableConfig: TableConfig) extends 
       params =
         columnConfigs.map { col =>
           termParam(col.modelFieldTerm, col.scalaType, default = col.scalaDefault)
-        }
+        },
+      inits = modelClassBases
     )()
 
-  def statements: List[Stat] = List(modelClass)
+  /** Base types for the model companion object (the `extends` clause).
+    *
+    * When non-empty, a companion object is generated. The base traits can contribute members through inheritance.
+    */
+  protected def modelObjectBases: List[Init] = Nil
+
+  protected def modelObject =
+    if (modelObjectBases.isEmpty)
+      None
+    else
+      Some(
+        defObject(
+          Term.Name(tableConfig.modelClassName),
+          modelObjectBases*
+        )()
+      )
+
+  def statements: List[Stat] = modelClass :: modelObject.toList
 }
 
 /** Code generator that produces a case class for each table to represent a row in code


### PR DESCRIPTION
ModelsObjectCodeGenerator: add modelClassBases, modelObjectBases, and
modelObject hooks for customizing the generated case class bases and
companion object generation.

EntityTableModulesObjectCodeGenerator: split tableModuleBase into
tableModuleBaseType and tableModuleBases to allow adding mixin traits
to the generated table module object.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
