### PR TITLE
Simplify codegen API with ColumnMetadata and streamlined method signatures

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/BasicGenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/BasicGenerationRules.scala
@@ -3,13 +3,6 @@ package slick.additions.codegen
 class BasicGenerationRules extends GenerationRules {
   override type ObjectConfigType = TableConfig
 
-  override protected def objectConfig(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  ): TableConfig =
-    TableConfig(
-      currentTableMetadata.table.name,
-      columnConfigs(currentTableMetadata, all),
-      namingRules
-    )
+  override protected def objectConfig(tableMetadata: GenerationRules.TableMetadata): TableConfig =
+    TableConfig(tableMetadata.table.name, columnConfigs(tableMetadata), namingRules)
 }

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
@@ -1,7 +1,5 @@
 package slick.additions.codegen
 
-import java.sql.Types
-
 import scala.concurrent.ExecutionContext
 import scala.meta.*
 
@@ -61,17 +59,37 @@ trait GenerationRules extends PartialFunctionUtils {
     *
     * @param column
     *   the column metadata
-    * @param currentTableMetadata
-    *   the table this column belongs to
     */
   // noinspection ScalaWeakerAccess,ScalaUnusedSymbol
-  protected def includeColumn(column: MColumn, currentTableMetadata: GenerationRules.TableMetadata): Boolean = true
+  protected def includeColumn(column: GenerationRules.ColumnMetadata): Boolean = true
 
   // noinspection ScalaWeakerAccess
   protected def namingRules: NamingRules = NamingRules.ModelSuffixedWithRow
 
+  /** Maps lowercase SQL type names to Scala types. This is a simpler hook than [[baseColumnType]] for when you only
+    * need to match on the type name string, without access to the full [[GenerationRules.ColumnMetadata]].
+    *
+    * Extend with `orElse` to add new type mappings as fallbacks, or with
+    * [[PartialFunction_asFallbackFor.asFallbackFor]] to override existing ones.
+    *
+    * @see
+    *   [[baseColumnType]], [[PostgresGenerationRules]]
+    */
+  protected def baseColumnTypeMapping: PartialFunction[String, Type] = {
+    case "numeric"                       => typ"BigDecimal"
+    case "double precision"              => typ"Double"
+    case "bigint"                        => typ"Long"
+    case "boolean"                       => typ"Boolean"
+    case "integer"                       => typ"Int"
+    case "character varying" | "varchar" => typ"String"
+    case "date"                          => term"java".termSelect(term"time").typeSelect(typ"LocalDate")
+  }
+
   /** Determine the base Scala type for a column. If the column is nullable, the type returned from this method will be
-    * wrapped in `Option[...]`.
+    * wrapped in `Option[...]`. After this, [[transformColumnType]] is called to allow further wrapping (e.g., for array
+    * columns).
+    *
+    * The default implementation delegates to [[baseColumnTypeMapping]] via the column's lowercase type name.
     *
     * Extend by overriding with `orElse` or [[PartialFunction_asFallbackFor.asFallbackFor]].
     *
@@ -83,24 +101,10 @@ trait GenerationRules extends PartialFunctionUtils {
     *   }
     *   }}}
     * @see
-    *   [[columnConfig]]
+    *   [[columnConfig]], [[baseColumnTypeMapping]]
     */
-  protected def baseColumnType(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  )
-    : PartialFunction[MColumn, Type] = {
-    case ColType(Types.NUMERIC, "numeric", _)                                => typ"BigDecimal"
-    case ColType(Types.DOUBLE, "double precision" | "float8", _)             => typ"Double"
-    case ColType(Types.BIGINT, "bigserial" | "bigint" | "int8", _)           => typ"Long"
-    case ColType(Types.BIT | Types.BOOLEAN, "bool" | "boolean", _)           => typ"Boolean"
-    case ColType(Types.INTEGER, _, _)                                        => typ"Int"
-    case ColType(Types.VARCHAR, "character varying" | "text" | "varchar", _) => typ"String"
-    case ColType(Types.DATE, "date", _)                                      =>
-      term"java".termSelect(term"time").typeSelect(typ"LocalDate")
-    case ColType(_, "lo", _)                                                 =>
-      term"java".termSelect(term"sql").typeSelect(typ"Blob")
-  }
+  protected def baseColumnType: PartialFunction[GenerationRules.ColumnMetadata, Type] =
+    Function.unlift(col => baseColumnTypeMapping.lift(col.typeNameLower))
 
   /** Determine the base Scala default value for a column. If the column is nullable, the expression returned from this
     * method will be wrapped in `Some(...)`.
@@ -119,81 +123,80 @@ trait GenerationRules extends PartialFunctionUtils {
     *   [[columnConfig]]
     */
   // noinspection ScalaWeakerAccess,ScalaUnusedSymbol
-  protected def baseColumnDefault(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  )
-    : PartialFunction[MColumn, Term] = {
-    case ColType(Types.BIT, "boolean" | "bool", Some(AsBoolean(b)))              => Lit.Boolean(b)
-    case ColType(Types.INTEGER, _, Some(AsInt(i)))                               => Lit.Int(i)
-    case ColType(Types.DOUBLE, "double precision" | "float8", Some(AsDouble(d))) => Lit.Double(d)
-    case ColType(Types.NUMERIC, "numeric", Some(s))                              =>
-      term"BigDecimal".termApply(Lit.String(s))
-    case ColType(Types.DATE, "date", Some("now()" | "LOCALTIMESTAMP"))           =>
-      term"java".termSelect("time").termSelect("LocalDate").termSelect("now")
-        .termApply()
-    case ColType(
-          Types.VARCHAR,
-          "character varying" | "text" | "varchar",
-          Some(s)
-        ) =>
-      Lit.String(s.stripPrefix("'").stripSuffix("'"))
+  protected def baseColumnDefault: PartialFunction[GenerationRules.ColumnMetadata, Term] = {
+    case ColType(_, "boolean", Some(AsBoolean(b)))            => Lit.Boolean(b)
+    case ColType(_, "integer", Some(AsInt(i)))                => Lit.Int(i)
+    case ColType(_, "double precision", Some(AsDouble(d)))    => Lit.Double(d)
+    case ColType(_, "character varying" | "varchar", Some(s)) => Lit.String(s.stripPrefix("'").stripSuffix("'"))
+    case ColType(_, "numeric", Some(s))                       => term"BigDecimal".termApply(Lit.String(s))
+    case ColType(_, "date", Some("now()" | "LOCALTIMESTAMP")) =>
+      term"java".termSelect("time").termSelect("LocalDate").termSelect("now").termApply()
   }
 
-  protected def baseColumnType(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata],
-    column: MColumn
-  ): Type =
-    baseColumnType(currentTableMetadata, all).applyOrElse(
-      column,
-      (_: MColumn) => {
-        logger.warn(
-          s"Column type not matched by `baseColumnType` for column: ${currentTableMetadata.table.name} ${column.name}"
-        )
-        typ"Nothing"
-      }
-    )
+  /** Hook to transform the resolved base type before nullable/Option wrapping. Override to customize the Scala type for
+    * specific columns (e.g., wrapping array columns in a collection type). The default implementation returns the base
+    * type unchanged.
+    *
+    * @param column
+    *   the column metadata
+    * @param baseType
+    *   the Scala type resolved by [[baseColumnType]]
+    * @return
+    *   the (possibly transformed) type
+    */
+  // noinspection ScalaWeakerAccess
+  protected def transformColumnType(column: GenerationRules.ColumnMetadata, baseType: Type): Type = baseType
 
   // noinspection ScalaWeakerAccess
-  protected def columnConfig(
-    column: MColumn,
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  )
-    : ColumnConfig = {
-    val ident    = Term.Name(namingRules.columnNameToIdentifier(column.name))
-    val typ0     = baseColumnType(currentTableMetadata, all, column)
-    val default0 = baseColumnDefault(currentTableMetadata, all).lift(column)
+  protected def columnConfig(columnMetadata: GenerationRules.ColumnMetadata): ColumnConfig = {
+    val ident = Term.Name(namingRules.columnNameToIdentifier(columnMetadata.name))
 
-    val (typ, default) =
-      if (!column.nullable.contains(true))
-        typ0                        -> default0
+    val baseDefault = baseColumnDefault.lift(columnMetadata)
+    val baseType    =
+      transformColumnType(
+        column = columnMetadata,
+        baseType =
+          baseColumnType.applyOrElse(
+            columnMetadata,
+            { (_: GenerationRules.ColumnMetadata) =>
+              logger.warn(
+                s"Column type not matched by `baseColumnType` for column: ${columnMetadata.table.name}.${columnMetadata.name}"
+              )
+              typ"Nothing"
+            }
+          )
+      )
+
+    val (fullType, fullDefault) =
+      if (!columnMetadata.nullable)
+        baseType                        -> baseDefault
       else
-        typ"Option".typeApply(typ0) ->
-          Some(default0.map(t => term"Some".termApply(t)).getOrElse(term"None"))
+        typ"Option".typeApply(baseType) -> Some(baseDefault.map(t => term"Some".termApply(t)).getOrElse(term"None"))
 
     ColumnConfig(
-      column = column,
+      column = columnMetadata.column,
       tableFieldTerm = ident,
       modelFieldTerm = ident,
-      scalaType = typ,
-      scalaDefault = default
+      scalaType = fullType,
+      scalaDefault = fullDefault
     )
   }
 
-  protected def columnConfigs(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  ) =
-    currentTableMetadata.columns.toList
-      .filter(includeColumn(_, currentTableMetadata))
-      .map(columnConfig(_, currentTableMetadata, all))
+  protected def columnConfigs(tableMetadata: GenerationRules.TableMetadata) =
+    tableMetadata.columns.toList.flatMap { column =>
+      val columnMetadata =
+        GenerationRules.ColumnMetadata(
+          column = column,
+          primaryKey = tableMetadata.primaryKeys.find(_.column == column.name),
+          foreignKey = tableMetadata.foreignKeys.find(_.fkColumn == column.name)
+        )
+      if (includeColumn(columnMetadata))
+        Some(columnConfig(columnMetadata))
+      else
+        None
+    }
 
-  protected def objectConfig(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  )
+  protected def objectConfig(tableMetadata: GenerationRules.TableMetadata)
     : ObjectConfigType
 
   def objectConfigs(slickProfileClass: Class[? <: JdbcProfile])(implicit ec: ExecutionContext)
@@ -216,7 +219,7 @@ trait GenerationRules extends PartialFunctionUtils {
                            )
                          }
                        )
-    } yield infos.map(objectConfig(_, infos))
+    } yield infos.map(objectConfig)
   }
 }
 object GenerationRules {
@@ -228,4 +231,17 @@ object GenerationRules {
     columns: Seq[MColumn],
     primaryKeys: Seq[MPrimaryKey],
     foreignKeys: Seq[MForeignKey])
+
+  /** Metadata about a single column, bundling the JDBC column info with its primary key and foreign key associations.
+    * This is the input type for [[GenerationRules.baseColumnType]], [[GenerationRules.baseColumnDefault]], and the
+    * extractors in the `codegen` package object ([[ColType]], [[ColName]]).
+    */
+  case class ColumnMetadata(column: MColumn, primaryKey: Option[MPrimaryKey], foreignKey: Option[MForeignKey]) {
+    def table         = column.table
+    def name          = column.name
+    def typeNameLower = column.typeName.toLowerCase
+    def jdbcType      = column.sqlType
+    def default       = column.columnDef
+    def nullable      = column.nullable.contains(true)
+  }
 }

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/PostgresGenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/PostgresGenerationRules.scala
@@ -2,31 +2,46 @@ package slick.additions.codegen
 
 import java.sql.Types
 
-import slick.additions.codegen.ScalaMetaDsl.{scalametaNonMacroInterpolators, scalametaTypeExtensionMethods}
+import scala.meta.{Lit, Term, Type}
+
+import slick.additions.codegen.ScalaMetaDsl.{
+  scalametaNonMacroInterpolators, scalametaTermExtensionMethods, scalametaTermRefExtensionMethods,
+  scalametaTypeExtensionMethods
+}
 
 
 trait PostgresGenerationRules extends GenerationRules {
-  override protected def baseColumnType(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  ) =
-    super.baseColumnType(currentTableMetadata, all)
-      .orElse {
-        case ColType(Types.TIMESTAMP, "timestamp", _) => typ"Instant"
-        case ColType(Types.TIME, "time", _)           => typ"LocalTime"
-      }
+  override protected def baseColumnTypeMapping =
+    super.baseColumnTypeMapping.orElse {
+      case "float8"                    => typ"Double"
+      case "int4" | "serial"           => typ"Int"
+      case "int8" | "bigserial"        => typ"Long"
+      case "bool"                      => typ"Boolean"
+      case "text"                      => typ"String"
+      case "timestamp" | "timestamptz" => typ"Instant"
+      case "time" | "timetz"           => typ"LocalTime"
+      case "lo"                        => term"java".termSelect(term"sql").typeSelect(typ"Blob")
+    }
+
+  final protected def isArray(column: GenerationRules.ColumnMetadata) = column.typeNameLower.startsWith("_")
+
+  override protected def baseColumnType: PartialFunction[GenerationRules.ColumnMetadata, Type] =
+    Function.unlift(col => baseColumnTypeMapping.lift(col.typeNameLower.stripPrefix("_")))
+
+  override protected def baseColumnDefault =
+    super.baseColumnDefault.orElse {
+      case ColType(_, "bool", Some(AsBoolean(b)))        => Lit.Boolean(b)
+      case ColType(_, "int4" | "serial", Some(AsInt(i))) => Lit.Int(i)
+      case ColType(_, "float8", Some(AsDouble(d)))       => Lit.Double(d)
+      case ColType(_, "text", Some(s))                   => Lit.String(s.stripPrefix("'").stripSuffix("'"))
+    }
 }
 
 //noinspection ScalaUnusedSymbol
 trait PostgresArrayGenerationRules extends PostgresGenerationRules {
-  override protected def baseColumnType(
-    currentTableMetadata: GenerationRules.TableMetadata,
-    all: Seq[GenerationRules.TableMetadata]
-  ) =
-    super.baseColumnType(currentTableMetadata, all)
-      .orElse {
-        case col @ ColType(Types.ARRAY, name, _) if name.startsWith("_") =>
-          val elementType = baseColumnType(currentTableMetadata, all, col.copy(typeName = name.stripPrefix("_")))
-          typ"List".typeApply(elementType)
-      }
+  override protected def transformColumnType(column: GenerationRules.ColumnMetadata, baseType: Type) =
+    if (isArray(column))
+      typ"List".typeApply(baseType)
+    else
+      super.transformColumnType(column, baseType)
 }

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/package.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/package.scala
@@ -2,8 +2,6 @@ package slick.additions
 
 import scala.util.Try
 
-import slick.jdbc.meta.MColumn
-
 
 package object codegen {
   def snakeToCamel(s: String) = {
@@ -24,19 +22,25 @@ package object codegen {
   val AsInt    = new TryExtractor(_.toInt)
   val AsDouble = new TryExtractor(_.toDouble)
 
+  /** Extractor that destructures a [[GenerationRules.ColumnMetadata]] into `(sqlType, typeNameLower, columnDef)`.
+    * Useful in [[GenerationRules.baseColumnDefault]] overrides for matching by type name and default value.
+    */
   object ColType {
-    def unapply(col: MColumn) = Some((col.sqlType, col.typeName.toLowerCase, col.columnDef))
+    def unapply(col: GenerationRules.ColumnMetadata) = Some((col.jdbcType, col.typeNameLower, col.default))
   }
 
-  /** Extractor for matching a column by its table name and column name. Useful in `columnTypeOverride` and
-    * `includeColumn` overrides for per-column matching.
+  /** Extractor for matching a column by its table name and column name. Useful in [[GenerationRules.baseColumnType]]
+    * and [[GenerationRules.includeColumn]] overrides for per-column matching.
     *
     * @example
     *   {{{
-    * case ColName("hotline", "phone_number") => typ"PhoneNumber"
+    * override def baseColumnType =
+    *   super.baseColumnType.asFallbackFor {
+    *     case ColName("hotline", "phone_number") => typ"PhoneNumber"
+    *   }
     *   }}}
     */
   object ColName {
-    def unapply(col: MColumn): Some[(String, String)] = Some((col.table.name, col.name))
+    def unapply(col: GenerationRules.ColumnMetadata): Some[(String, String)] = Some((col.table.name, col.name))
   }
 }


### PR DESCRIPTION
Introduce GenerationRules.ColumnMetadata to bundle column, primary key,
and foreign key info, replacing the pattern of threading raw MColumn +
TableMetadata + all tables through every method. This eliminates the
`currentTableMetadata`/`all` parameters from baseColumnType,
baseColumnDefault, columnConfig, columnConfigs, objectConfig, and
includeColumn.

Add baseColumnTypeMapping as a simpler PartialFunction[String, Type] hook
for type-name-only matching, with baseColumnType delegating to it.

Rename wrapColumnType to transformColumnType to better reflect its
general-purpose nature, and simplify its signature to only return Type
(removing the default value parameter).

Move Postgres-specific type mappings and defaults into
PostgresGenerationRules using the new baseColumnTypeMapping/
baseColumnDefault hooks. Simplify PostgresArrayGenerationRules to use
an isArray helper and transformColumnType override.

Update ColType and ColName extractors to work with ColumnMetadata.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
