### PR TITLE
Add support for `bigint` and `bigserial` defaults in GenerationRules

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
@@ -126,6 +126,7 @@ trait GenerationRules extends PartialFunctionUtils {
   protected def baseColumnDefault: PartialFunction[GenerationRules.ColumnMetadata, Term] = {
     case ColType(_, "boolean", Some(AsBoolean(b)))            => Lit.Boolean(b)
     case ColType(_, "integer", Some(AsInt(i)))                => Lit.Int(i)
+    case ColType(_, "bigint", Some(AsLong(l)))                => Lit.Long(l)
     case ColType(_, "double precision", Some(AsDouble(d)))    => Lit.Double(d)
     case ColType(_, "character varying" | "varchar", Some(s)) => Lit.String(s.stripPrefix("'").stripSuffix("'"))
     case ColType(_, "numeric", Some(s))                       => term"BigDecimal".termApply(Lit.String(s))

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/PostgresGenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/PostgresGenerationRules.scala
@@ -30,10 +30,13 @@ trait PostgresGenerationRules extends GenerationRules {
 
   override protected def baseColumnDefault =
     super.baseColumnDefault.orElse {
-      case ColType(_, "bool", Some(AsBoolean(b)))        => Lit.Boolean(b)
-      case ColType(_, "int4" | "serial", Some(AsInt(i))) => Lit.Int(i)
-      case ColType(_, "float8", Some(AsDouble(d)))       => Lit.Double(d)
-      case ColType(_, "text", Some(s))                   => Lit.String(s.stripPrefix("'").stripSuffix("'"))
+      case ColType(_, "bool", Some(AsBoolean(b)))                                    => Lit.Boolean(b)
+      case ColType(_, "int4" | "serial", Some(AsInt(i)))                             => Lit.Int(i)
+      case ColType(_, "int8" | "bigserial", Some(AsLong(l)))                         => Lit.Long(l)
+      case ColType(_, "float8", Some(AsDouble(d)))                                   => Lit.Double(d)
+      case ColType(_, "text", Some(s))                                               => Lit.String(s.stripPrefix("'").stripSuffix("'"))
+      case ColType(_, "timestamp" | "timestamptz", Some("now()" | "LOCALTIMESTAMP")) =>
+        term"java".termSelect("time").termSelect("Instant").termSelect("now").termApply()
     }
 }
 

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/package.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/package.scala
@@ -19,8 +19,9 @@ package object codegen {
     def unapply(string: String) = Try(f(string)).toOption
   }
   val AsBoolean = new TryExtractor(_.toBoolean)
-  val AsInt    = new TryExtractor(_.toInt)
-  val AsDouble = new TryExtractor(_.toDouble)
+  val AsInt     = new TryExtractor(_.toInt)
+  val AsLong    = new TryExtractor(_.toLong)
+  val AsDouble  = new TryExtractor(_.toDouble)
 
   /** Extractor that destructures a [[GenerationRules.ColumnMetadata]] into `(sqlType, typeNameLower, columnDef)`.
     * Useful in [[GenerationRules.baseColumnDefault]] overrides for matching by type name and default value.


### PR DESCRIPTION
Extend `baseColumnDefault` to handle `bigint` and `bigserial` types using `AsLong`. Update `TryExtractor` to include `AsLong` parsing logic. Enhance Postgres-specific type mappings and defaults accordingly.
