### PR TITLE
Replace annotation-based Circe/Monocle codegen with semi-auto derivation

### DIFF
--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/BaseModelsObjectCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/BaseModelsObjectCodeGenerator.scala
@@ -14,8 +14,9 @@ import slick.additions.codegen.ScalaMetaDsl.{defClass, defObject, termParam}
   * @see
   *   [[EntityModelsObjectCodeGenerator]] which filters out primary key columns
   */
-class BaseModelsObjectCodeGenerator(protected val modelClassName: String, columnConfigs: List[ColumnConfig])
-    extends ObjectCodeGenerator {
+class BaseModelsObjectCodeGenerator(
+  protected val modelClassName: String,
+  protected val columnConfigs: List[ColumnConfig]) extends ObjectCodeGenerator {
 
   /** Base types for the model case class (the `extends` clause).
     *
@@ -36,19 +37,25 @@ class BaseModelsObjectCodeGenerator(protected val modelClassName: String, column
 
   /** Base types for the model companion object (the `extends` clause).
     *
-    * When non-empty, a companion object is generated. The base traits can contribute members through inheritance.
+    * When non-empty (or when [[modelObjectStatements]] is non-empty), a companion object is generated.
     */
   protected def modelObjectBases: List[Init] = Nil
 
+  /** Statements to include in the model companion object body.
+    *
+    * Override to add members such as implicit codec instances or lenses.
+    */
+  protected def modelObjectStatements: List[Stat] = Nil
+
   protected def modelObject =
-    if (modelObjectBases.isEmpty)
+    if (modelObjectBases.isEmpty && modelObjectStatements.isEmpty)
       None
     else
       Some(
         defObject(
           Term.Name(modelClassName),
           modelObjectBases*
-        )()
+        )(modelObjectStatements)
       )
 
   def statements: List[Stat] = modelClass :: modelObject.toList

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/extra/circe/CirceJsonCodecModelsObjectCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/extra/circe/CirceJsonCodecModelsObjectCodeGenerator.scala
@@ -1,24 +1,40 @@
 package slick.additions.codegen.extra.circe
 
-import scala.meta.Mod
+import scala.meta.{Mod, Stat}
 
 import slick.additions.codegen.ScalaMetaDsl.*
 import slick.additions.codegen.{BaseModelsObjectCodeGenerator, ModelsFileCodeGenerator}
 
 
-/** Annotates model classes with Circe's `@JsonCodec`.
+/** Adds semi-auto derived Circe `Encoder` and `Decoder` instances to the model companion object.
   *
-  * Generated code requires `circe-generic`
+  * Generated code requires `circe-generic`.
   */
 //noinspection ScalaUnusedSymbol
 trait CirceJsonCodecModelsObjectCodeGenerator extends BaseModelsObjectCodeGenerator {
-  override protected def modelClass =
-    super
-      .modelClass
-      .withMod(Mod.Annot(init(typ"JsonCodec")))
+  override protected def modelObjectStatements: List[Stat] = {
+    val modelType = typ"$modelClassName"
 
+    def deriver(prefix: String, typeClass: String, method: String) =
+      defVal(
+        name = term"${prefix + modelClassName}",
+        declaredType = Some(typ"$typeClass".typeApply(modelType)),
+        modifiers = Seq(Mod.Implicit())
+      )(
+        term"$method".termApplyType(modelType)
+      )
+
+    super.modelObjectStatements ++ List(
+      deriver("encode", "Encoder", "deriveEncoder"),
+      deriver("decode", "Decoder", "deriveDecoder")
+    )
+  }
 }
 //noinspection ScalaUnusedSymbol
-trait CirceJsonCodecModelsFileCodeGenerator extends ModelsFileCodeGenerator {
-  override def imports = super.imports :+ "io.circe.generic.JsonCodec"
+trait CirceJsonCodecModelsFileCodeGenerator   extends ModelsFileCodeGenerator       {
+  override def imports =
+    super.imports ++ List(
+      "io.circe.{Decoder, Encoder}",
+      "io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}"
+    )
 }

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/extra/monocle/MonocleLensesModelsObjectCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/extra/monocle/MonocleLensesModelsObjectCodeGenerator.scala
@@ -3,25 +3,45 @@ package slick.additions.codegen.extra.monocle
 import scala.meta.*
 
 import slick.additions.codegen.ScalaMetaDsl.*
-import slick.additions.codegen.{BaseModelsObjectCodeGenerator, ModelsFileCodeGenerator}
+import slick.additions.codegen.{BaseModelsObjectCodeGenerator, ColumnConfig, ModelsFileCodeGenerator}
 
 
-/** Annotates model classes with Monocle's `@Lenses`.
+/** Adds Monocle `GenLens`-based lenses for each model field to the companion object.
   *
-  * Generated code requires `monocle-macro`
+  * Generated code requires `monocle-macro`.
   */
 trait MonocleLensesModelsObjectCodeGenerator extends BaseModelsObjectCodeGenerator {
-  override protected def modelClass =
-    super
-      .modelClass
-      .withMod(Mod.Annot(init(typ"Lenses")))
 
-  override def statements =
-    List(
-      modelClass,
-      defObject(Term.Name(modelClassName))()
-    )
+  /** The val name for a generated lens. Defaults to the field name (e.g., field `name` produces
+    * `val name: Lens[Model, String]`).
+    *
+    * @example
+    *   To prefix lens names with "lens" and capitalize:
+    *   {{{
+    * override protected def lensName(col: ColumnConfig) =
+    *   "lens" + col.modelFieldTerm.value.capitalize
+    *   }}}
+    */
+  protected def lensName(col: ColumnConfig): String = col.modelFieldTerm.value
+
+  override protected def modelObjectStatements: List[Stat] = {
+    val modelType = typ"$modelClassName"
+    val lenses    = columnConfigs.map { col =>
+      defVal(
+        term"${lensName(col)}",
+        Some(typ"Lens".typeApply(modelType, col.scalaType))
+      )(
+        term"GenLens".termApplyType(modelType)
+          .termApply(Term.AnonymousFunction(Term.Placeholder().termSelect(col.modelFieldTerm)))
+      )
+    }
+    super.modelObjectStatements ++ lenses
+  }
 }
-trait MonocleLensesModelsFileCodeGenerator   extends ModelsFileCodeGenerator       {
-  override def imports = super.imports :+ "monocle.macros.Lenses"
+trait MonocleLensesModelsFileCodeGenerator extends ModelsFileCodeGenerator {
+  override def imports =
+    super.imports ++ List(
+      "monocle.Lens",
+      "monocle.macros.GenLens"
+    )
 }


### PR DESCRIPTION
Annotation macros (@JsonCodec, @Lenses) are not supported in Scala 3.
Switch to semi-auto derivation (deriveEncoder/deriveDecoder, GenLens)
generated in companion objects via the new modelObjectStatements hook.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
