### PR TITLE
CI: bump JDK to temurin@17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.x, 2.13.x, 3.3.x]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -32,12 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt
@@ -75,7 +75,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.3.8]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -83,12 +83,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: sbt
 
       - name: Setup sbt

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,9 +8,9 @@ pull_request_rules:
       - or:
           - author=scala-steward
           - author=nafg-scala-steward[bot]
-      - check-success=Build and Test (ubuntu-latest, 2.12.x, temurin@11)
-      - check-success=Build and Test (ubuntu-latest, 2.13.x, temurin@11)
-      - check-success=Build and Test (ubuntu-latest, 3.3.x, temurin@11)
+      - check-success=Build and Test (ubuntu-latest, 2.12.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 2.13.x, temurin@17)
+      - check-success=Build and Test (ubuntu-latest, 3.3.x, temurin@17)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -44,7 +44,7 @@ inThisBuild(List(
       name = Some("Check that codegen output hasn't changed")
     )
   ),
-  githubWorkflowJavaVersions          := Seq(JavaSpec.temurin("11")),
+  githubWorkflowJavaVersions          := Seq(JavaSpec.temurin("17")),
   githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
   githubWorkflowPublish               := Seq(
     WorkflowStep.Sbt(


### PR DESCRIPTION
sbt 2.x requires JDK 17+, so the scala-steward "Update sbt to 2.0.x" PR cannot pass CI while `githubWorkflowJavaVersions` is pinned to `temurin@11`. Bumped to `temurin@17` in `ci.sbt` and regenerated the workflow with `githubWorkflowGenerate` (which also refreshed the check names in `.mergify.yml`).

Verified locally on JDK 17: `githubWorkflowCheck` and `+test` both pass across 2.12/2.13/3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build and publishing environments to Java 17.
  - Refreshed GitHub Actions tooling for improved workflow compatibility.
  - Updated supported Scala publishing configuration to version 3.3.8.
  - Improved artifact handling and command sequencing in automated workflows.
  - Updated automated merge checks to use Java 17 across supported Scala versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->