### PR TITLE
Migrate to Slick 4.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val `slick-additions-entity` =
   crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure)
     .settings()
 
-val slickVersion = "3.6.1"
+val slickVersion = "4.0.0-RC2"
 
 lazy val `slick-additions` = (project in file("."))
   .dependsOn(`slick-additions-entity`.jvm)
@@ -33,6 +33,7 @@ lazy val `slick-additions` = (project in file("."))
   .settings(
     libraryDependencies ++= Seq(
       "com.typesafe.slick" %% "slick"           % slickVersion,
+      "com.typesafe.slick" %% "slick-future"    % slickVersion % "test",
       "com.lihaoyi"        %% "sourcecode"      % "0.4.4",
       "org.scalatest"      %% "scalatest"       % "3.2.20"  % "test",
       "com.h2database"      % "h2"              % "2.5.250" % "test",
@@ -45,6 +46,7 @@ lazy val `slick-additions-codegen` =
     .settings(
       libraryDependencies ++= Seq(
         "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
+        "com.typesafe.slick" %% "slick-future"   % slickVersion,
         ("org.scalameta"     %% "scalameta"      % "4.17.3")
           .cross(CrossVersion.for3Use2_13),
         ("org.scalameta"     %% "scalafmt-core"  % "3.11.5")

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/FileCodeGenerator.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/FileCodeGenerator.scala
@@ -3,12 +3,13 @@ package slick.additions.codegen
 import java.nio.file.{Files, Path}
 
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{Await, Future}
 import scala.meta.{Pkg, Stat, XtensionSyntax}
 
 import slick.additions.codegen.ScalaMetaDsl.*
 import slick.dbio.DBIO
-import slick.jdbc.{JdbcBackend, JdbcProfile}
+import slick.future.Database
+import slick.jdbc.{DatabaseConfig, JdbcProfile}
 
 import com.typesafe.config.Config
 import org.scalafmt.Scalafmt
@@ -70,18 +71,16 @@ trait FileCodeGenerator {
     )
       .syntax
 
-  def codeString(slickProfileClass: Class[? <: JdbcProfile])(implicit executionContext: ExecutionContext)
-    : DBIO[String] =
+  def codeString(slickProfileClass: Class[? <: JdbcProfile]): DBIO[String] =
     generationRules.objectConfigs(slickProfileClass)
       .map(codeString(_, generationRules.extraImports, slickProfileClass))
 
-  def codeString(slickProfileClassName: String)(implicit executionContext: ExecutionContext)
-    : DBIO[String] = codeString(Class.forName(slickProfileClassName).asSubclass(classOf[JdbcProfile]))
+  def codeString(slickProfileClassName: String): DBIO[String] =
+    codeString(Class.forName(slickProfileClassName).asSubclass(classOf[JdbcProfile]))
 
   def codeStringFormatted(
     slickProfileClassName: String,
     scalafmtConfig: ScalafmtConfig = ScalafmtConfig.defaultWithAlign
-  )(implicit executionContext: ExecutionContext
   ): DBIO[String] =
     codeString(Class.forName(slickProfileClassName).asSubclass(classOf[JdbcProfile]))
       .flatMap { str =>
@@ -90,11 +89,7 @@ trait FileCodeGenerator {
       }
 
   // noinspection ScalaWeakerAccess
-  def writeToFileDBIO(
-    baseDir: Path,
-    slickConfig: Config
-  )(implicit executionContext: ExecutionContext
-  ) =
+  def writeToFileDBIO(baseDir: Path, slickConfig: Config) =
     codeStringFormatted(slickConfig.getString("profile")).map { codeStr =>
       val path = filePath(baseDir)
       Files.createDirectories(path.getParent)
@@ -106,9 +101,8 @@ trait FileCodeGenerator {
     baseDir: Path,
     slickConfig: Config,
     timeout: Duration = Duration.Inf
-  )(implicit executionContext: ExecutionContext
   ): Path = {
-    val db = JdbcBackend.Database.forConfig("", slickConfig)
+    val db = Await.result(Database.open(DatabaseConfig.forConfig[JdbcProfile]("", slickConfig)), timeout)
 
     try
       Await.result(db.run(writeToFileDBIO(baseDir, slickConfig)), timeout)

--- a/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
+++ b/slick-additions-codegen/src/main/scala/slick/additions/codegen/GenerationRules.scala
@@ -1,6 +1,5 @@
 package slick.additions.codegen
 
-import scala.concurrent.ExecutionContext
 import scala.meta.*
 
 import slick.additions.codegen.ScalaMetaDsl.*
@@ -206,8 +205,7 @@ trait GenerationRules extends PartialFunctionUtils {
   protected def objectConfig(tableMetadata: GenerationRules.TableMetadata)
     : ObjectConfigType
 
-  def objectConfigs(slickProfileClass: Class[? <: JdbcProfile])(implicit ec: ExecutionContext)
-    : DBIO[List[ObjectConfigType]] = {
+  def objectConfigs(slickProfileClass: Class[? <: JdbcProfile]): DBIO[List[ObjectConfigType]] = {
     val slickProfileInstance = slickProfileClass.getField("MODULE$").get(null).asInstanceOf[JdbcProfile]
     for {
       tables        <- slickProfileInstance.defaultTables

--- a/slick-additions-codegen/src/test/scala/slick/additions/codegen/CodeGen.scala
+++ b/slick-additions-codegen/src/test/scala/slick/additions/codegen/CodeGen.scala
@@ -1,8 +1,5 @@
 package slick.additions.codegen
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
-
 object CodeGen extends App {
   for (codeGeneration <- TestFileCodeGenerator.all)
     Util.writeToFile(codeGeneration)

--- a/slick-additions-codegen/src/test/scala/slick/additions/codegen/Util.scala
+++ b/slick-additions-codegen/src/test/scala/slick/additions/codegen/Util.scala
@@ -4,33 +4,23 @@ import java.nio.file.Paths
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import slick.future.Database
+import slick.jdbc.{DatabaseConfig, H2Profile}
+
 import com.typesafe.config.ConfigFactory
-import org.scalatest.CompleteLastly
 
 
-object Util extends CompleteLastly {
-  private val profile = slick.jdbc.H2Profile
-
-  import profile.api.*
-
-
+object Util {
   private val slickConfig = ConfigFactory.parseResources("config.conf")
-  private def db          = Database.forConfig("", slickConfig)
 
-  def writeToFile(generator: FileCodeGenerator)(implicit executionContext: ExecutionContext) =
+  def writeToFile(generator: FileCodeGenerator) =
     generator.writeToFileSync(
       Paths.get(s"slick-additions-codegen/src/test/resources"),
       Util.slickConfig
     )
 
-  def codeString(generator: FileCodeGenerator)(implicit executionContext: ExecutionContext)
-    : Future[String] =
-    complete {
-      db.run(
-        generator.codeStringFormatted(
-          Util.slickConfig.getString("profile")
-        )
-      )
+  def codeString(generator: FileCodeGenerator)(implicit executionContext: ExecutionContext): Future[String] =
+    Database.use(DatabaseConfig.forConfig[H2Profile]("", slickConfig)) { db =>
+      db.run(generator.codeStringFormatted(slickConfig.getString("profile")))
     }
-      .lastly(db.close())
 }

--- a/slick-additions-testcontainers/src/main/scala/slick/additions/testcontainers/SlickPostgresContainer.scala
+++ b/slick-additions-testcontainers/src/main/scala/slick/additions/testcontainers/SlickPostgresContainer.scala
@@ -1,7 +1,7 @@
 package slick.additions.testcontainers
 
-import slick.jdbc.JdbcBackend
-import slick.util.AsyncExecutor
+import slick.ControlsConfig
+import slick.jdbc.{DatabaseConfig, JdbcDatabaseConfig, JdbcProfile, PostgresProfile}
 
 import com.typesafe.config.ConfigFactory
 import org.testcontainers.containers.PostgreSQLContainer
@@ -26,37 +26,39 @@ class SlickPostgresContainer(imageName: DockerImageName = DockerImageName.parse(
     */
   def port = getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
 
-  /** Returns a Slick Database object that can connect to the database and run Slick actions.
+  /** Returns a Slick `DatabaseConfig` that connects to the database. Pass it to `Database.open` or `Database.use` of
+    * whichever Slick facade you use (`slick.future.Database`, `slick.cats.Database`, `slick.zio.Database`).
     *
-    * @param backend
-    *   a [[JdbcBackend]]. Optional, but it may be necessary to pass e.g., `MyProfile.backend` to infer the right
-    *   path-dependent type.
+    * @param profile
+    *   the Slick profile, defaults to `PostgresProfile`. Pass your own profile to get a config typed for it.
     * @param databaseName
     *   Optionally specify a database name. Otherwise [[getDatabaseName]] will be used.
-    * @param numThreads
-    *   The size of Slick's thread pool (default 20)
+    * @param maxConnections
+    *   The maximum number of concurrent connections (default 20)
     * @param queueSize
-    *   The job queue size, 0 for direct hand-off or -1 for unlimited size. Defaults to 1000.
+    *   The maximum number of actions waiting for a connection slot before being rejected. Defaults to 1000.
     *
     * @see
-    *   [[AsyncExecutor]]
+    *   [[ControlsConfig]]
     */
-  def slickDatabase(
-    backend: JdbcBackend = JdbcBackend,
+  def slickDatabaseConfig[P <: JdbcProfile](
+    profile: P = PostgresProfile,
     databaseName: String = getDatabaseName,
-    numThreads: Int = 20,
+    maxConnections: Int = 20,
     queueSize: Int = 1000
-  ) =
-    backend.Database.forURL(
-      url = s"jdbc:postgresql://$getHost:$port/$databaseName",
-      user = getUsername,
-      password = getPassword,
-      driver = "org.postgresql.Driver",
-      executor = AsyncExecutor(s"slick-postgres-testcontainers-$getContainerId", numThreads, queueSize)
-    )
+  ): JdbcDatabaseConfig[P] =
+    DatabaseConfig
+      .forURL(
+        profile,
+        url = s"jdbc:postgresql://$getHost:$port/$databaseName",
+        user = getUsername,
+        password = getPassword,
+        driver = "org.postgresql.Driver"
+      )
+      .withControls(ControlsConfig(maxConnections = maxConnections, queueSize = queueSize))
 
   /** Returns a Typesafe Config object that describes how to connect to the database. It can be passed to
-    * `Database.forConfig` to get a Database object.
+    * `DatabaseConfig.forConfig` to get a `DatabaseConfig`.
     *
     * @param databaseName
     *   optionally specify a database name other than the TestContainers default
@@ -66,8 +68,9 @@ class SlickPostgresContainer(imageName: DockerImageName = DockerImageName.parse(
     *     val container = new SlickPostgresContainer
     *     container.start()
     *
-    *     import slick.jdbc.PostgresProfile.api.*
-    *     val database = Database.forConfig("", container.slickConfig)
+    *     import slick.future.Database
+    *     import slick.jdbc.{DatabaseConfig, PostgresProfile}
+    *     val database = Database.open(DatabaseConfig.forProfileConfig(PostgresProfile, "", container.slickConfig))
     *   }}}
     */
   def slickConfig(databaseName: String = getDatabaseName) =
@@ -84,7 +87,6 @@ class SlickPostgresContainer(imageName: DockerImageName = DockerImageName.parse(
            |}
            |profile = "slick.jdbc.PostgresProfile$$"
            |
-           |numThreads = 10
            |maxConnections = 10
            |""".stripMargin
       )

--- a/src/main/scala/slick/additions/AdditionsProfile.scala
+++ b/src/main/scala/slick/additions/AdditionsProfile.scala
@@ -1,7 +1,6 @@
 package slick
 package additions
 
-import scala.concurrent.ExecutionContext
 import scala.language.implicitConversions
 
 import slick.additions.entity._
@@ -89,9 +88,9 @@ trait AdditionsProfile { this: JdbcProfile =>
 
       def forInsertQuery[E, C[_]](q: Query[T, E, C]) = q.map(_.mapping)
 
-      def insert(v: V)(implicit ec: ExecutionContext): DBIO[SavedEntity[K, V]] = insert(Ent(v): Ent)
+      def insert(v: V): DBIO[SavedEntity[K, V]] = insert(Ent(v): Ent)
 
-      def insert(e: Ent)(implicit ec: ExecutionContext): DBIO[SavedEntity[K, V]] = {
+      def insert(e: Ent): DBIO[SavedEntity[K, V]] = {
         // Insert it and get the new or old key
         val action = e match {
           case ke: this.KEnt =>
@@ -102,17 +101,17 @@ trait AdditionsProfile { this: JdbcProfile =>
         action.map(l => SavedEntity(l.key, e.value))
       }
 
-      def update(ke: KEnt)(implicit ec: ExecutionContext): DBIO[SavedEntity[K, V]] =
+      def update(ke: KEnt): DBIO[SavedEntity[K, V]] =
         forInsertQuery(lookupQuery(ke)).update(ke.value)
           .map(_ => SavedEntity(ke.key, ke.value))
 
-      def save(e: Entity[K, V])(implicit ec: ExecutionContext): DBIO[SavedEntity[K, V]] =
+      def save(e: Entity[K, V]): DBIO[SavedEntity[K, V]] =
         e match {
           case ke: KEnt => update(ke)
           case ke: Ent  => insert(ke)
         }
 
-      def delete(ke: Lookup)(implicit ec: ExecutionContext) = lookupQuery(ke).delete
+      def delete(ke: Lookup) = lookupQuery(ke).delete
     }
 
     trait AutoName { this: Table[_] =>

--- a/src/test/scala/slick/additions/KeyedTableTests.scala
+++ b/src/test/scala/slick/additions/KeyedTableTests.scala
@@ -1,7 +1,5 @@
 package slick.additions
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 import slick.additions.entity.EntityKey
 import slick.additions.test.TestProfile.api._
 import slick.additions.test.TestsCommon

--- a/src/test/scala/slick/additions/test/TestsCommon.scala
+++ b/src/test/scala/slick/additions/test/TestsCommon.scala
@@ -1,5 +1,11 @@
 package slick.additions.test
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+import slick.future.Database
+import slick.jdbc.DatabaseConfig
+
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfter, Suite}
 
@@ -11,7 +17,17 @@ trait TestsCommon extends BeforeAndAfter with ScalaFutures { this: Suite =>
 
   def schema: TestProfile.DDL
 
-  val db = Database.forURL(s"jdbc:h2:mem:${getClass.getSimpleName};DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+  val db =
+    Await.result(
+      Database.open(
+        DatabaseConfig.forURL(
+          TestProfile,
+          s"jdbc:h2:mem:${getClass.getSimpleName};DB_CLOSE_DELAY=-1",
+          driver = "org.h2.Driver"
+        )
+      ),
+      Duration.Inf
+    )
 
   before {
     db.run(schema.create).futureValue


### PR DESCRIPTION
Migrates all modules to Slick 4.0.0-RC2 (requires the Scala 3.9.0 bump from #671, already on master).

Slick 4 removes `Database.forXxx`, `AsyncExecutor`, and the `ExecutionContext` parameter on `DBIOAction` combinators, and moves the `Future`-based `Database` into the `slick-future` module.

## Changes
- **build.sbt**: Slick 3.6.1 → 4.0.0-RC2. `slick-future` added to codegen, and to the root module in test scope only. The published `slick-additions` and `slick-additions-testcontainers` artifacts depend on no facade.
- **AdditionsProfile**: `EntTableQuery.insert`/`update`/`save`/`delete` no longer take an implicit `ExecutionContext` (source-breaking for callers that passed one explicitly).
- **Codegen**: same `ExecutionContext` removal on `FileCodeGenerator`/`GenerationRules`; `writeToFileSync` opens a `slick.future.Database` from `DatabaseConfig.forConfig`.
- **SlickPostgresContainer**: `slickDatabase` is removed. It would have to pick a facade on the caller's behalf, so it is replaced by `slickDatabaseConfig`, which returns a profile-typed `JdbcDatabaseConfig` to open with `slick.future.Database`, `slick.cats.Database`, or `slick.zio.Database`. `numThreads` → `maxConnections` via `ControlsConfig`; legacy `numThreads` key dropped from `slickConfig`.
- **Tests**: open the H2 database via `DatabaseConfig.forURL` + `Database.open`.

## Verification
- `sbt +compile`, `+Test/compile`, `+test` pass on 2.12.21, 2.13.18, 3.9.0
- Codegen regeneration leaves golden files unchanged; `test-codegen/compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Slick 4.0.0-RC2 and the Slick Future database module.
  * Added configurable database settings for PostgreSQL test containers, including profile and connection-pool configuration.

* **Improvements**
  * Simplified database operations and code generation APIs by removing the need to provide an execution context explicitly.
  * Updated database handling to use asynchronous database opening and managed resource usage.
  * Updated examples and test infrastructure for the newer database APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->