### PR TITLE
Make slick-additions-testcontainers facade-neutral

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,9 +72,8 @@ lazy val `slick-additions-testcontainers` =
   project
     .settings(
       libraryDependencies ++= Seq(
-        "com.typesafe"        % "config"       % "1.4.9",
-        "com.typesafe.slick" %% "slick"        % slickVersion,
-        "com.typesafe.slick" %% "slick-future" % slickVersion,
-        "org.testcontainers"  % "postgresql"   % "1.21.4"
+        "com.typesafe"        % "config"     % "1.4.9",
+        "com.typesafe.slick" %% "slick"      % slickVersion,
+        "org.testcontainers"  % "postgresql" % "1.21.4"
       )
     )

--- a/slick-additions-testcontainers/src/main/scala/slick/additions/testcontainers/SlickPostgresContainer.scala
+++ b/slick-additions-testcontainers/src/main/scala/slick/additions/testcontainers/SlickPostgresContainer.scala
@@ -1,9 +1,6 @@
 package slick.additions.testcontainers
 
-import scala.concurrent.Future
-
 import slick.ControlsConfig
-import slick.future.Database
 import slick.jdbc.{DatabaseConfig, JdbcDatabaseConfig, JdbcProfile, PostgresProfile}
 
 import com.typesafe.config.ConfigFactory
@@ -59,26 +56,6 @@ class SlickPostgresContainer(imageName: DockerImageName = DockerImageName.parse(
         driver = "org.postgresql.Driver"
       )
       .withControls(ControlsConfig(maxConnections = maxConnections, queueSize = queueSize))
-
-  /** Opens a `Future`-based Slick Database object that can connect to the database and run Slick actions. The caller is
-    * responsible for calling `close()` on it.
-    *
-    * @param databaseName
-    *   Optionally specify a database name. Otherwise [[getDatabaseName]] will be used.
-    * @param maxConnections
-    *   The maximum number of concurrent connections (default 20)
-    * @param queueSize
-    *   The maximum number of actions waiting for a connection slot before being rejected. Defaults to 1000.
-    *
-    * @see
-    *   [[slickDatabaseConfig]]
-    */
-  def slickDatabase(
-    databaseName: String = getDatabaseName,
-    maxConnections: Int = 20,
-    queueSize: Int = 1000
-  ): Future[Database] =
-    Database.open(slickDatabaseConfig(PostgresProfile, databaseName, maxConnections, queueSize))
 
   /** Returns a Typesafe Config object that describes how to connect to the database. It can be passed to
     * `DatabaseConfig.forConfig` to get a `DatabaseConfig`.


### PR DESCRIPTION
Stacked on #672.

Removes `SlickPostgresContainer.slickDatabase` and the module's `slick-future` dependency. `slickDatabaseConfig` returns a `JdbcDatabaseConfig[P]` that can be opened with any Slick 4 facade (`slick.future.Database`, `slick.cats.Database`, `slick.zio.Database`), so the module no longer commits users to `Future`.

## Verification
- `sbt +slick-additions-testcontainers/compile` passes on 2.12.21, 2.13.18, 3.9.0
- scalafmt check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
